### PR TITLE
Removed forced 'time.month' grouping in `adjust_3d` when no group was specified

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -425,21 +425,22 @@ disable=raw-checker-failed,
         multiple-statements,
         line-too-long,
         import-error,
-        consider-using-with
+        consider-using-with,
+        c-extension-no-member
 
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once). See also the "--disable" option for examples.
-enable=c-extension-no-member
+enable=
 
 
 [METHOD_ARGS]
 
 # List of qualified names (i.e., library.method) which require a timeout
 # parameter e.g. 'requests.api.get,requests.api.post'
-timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
+# timeout-methods=requests.api.delete,requests.api.get,requests.api.head,requests.api.options,requests.api.patch,requests.api.post,requests.api.put,requests.api.request
 
 
 [MISCELLANEOUS]

--- a/cmethods/CMethods.py
+++ b/cmethods/CMethods.py
@@ -718,7 +718,9 @@ class CMethods:
 
             res.values = QDM1 * delta  # Eq. 2.4
             return res
-        raise ValueError(f"Unknown kind {kind}!")
+        raise NotImplementedError(
+            f"{kind} not available for quantile_delta_mapping. Use '+' or '*' instead."
+        )
 
     # * -----========= G E N E R A L  =========------
     @staticmethod

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,6 @@
+netCDF4>=1.6.1
 numpy
+pytest
 scikit-learn
-xarray
+tqdm
+xarray>=2022.11.0

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -339,7 +339,7 @@ class TestMethods(unittest.TestCase):
 
     def test_not_implemented_methods(self) -> None:
         kind = "+"
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             CMethods.empirical_quantile_mapping(
                 self.data[kind]["obsh"],
                 self.data[kind]["simh"],
@@ -349,28 +349,28 @@ class TestMethods(unittest.TestCase):
 
     def test_invalid_adjustment_type(self) -> None:
         kind = "+"
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             CMethods.linear_scaling(
                 self.data[kind]["obsh"],
                 self.data[kind]["simh"],
                 self.data[kind]["simp"],
                 kind="/",
             )
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             CMethods.variance_scaling(
                 self.data[kind]["obsh"],
                 self.data[kind]["simh"],
                 self.data[kind]["simp"],
                 kind="*",
             )
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             CMethods.delta_method(
                 self.data[kind]["obsh"],
                 self.data[kind]["simh"],
                 self.data[kind]["simp"],
                 kind="/",
             )
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             CMethods.quantile_mapping(
                 self.data[kind]["obsh"],
                 self.data[kind]["simh"],
@@ -378,7 +378,7 @@ class TestMethods(unittest.TestCase):
                 kind="/",
                 n_quantiles=10,
             )
-        with pytest.raises(ValueError):
+        with pytest.raises(NotImplementedError):
             CMethods.quantile_delta_mapping(
                 self.data[kind]["obsh"],
                 self.data[kind]["simh"],

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -240,7 +240,7 @@ class TestMethods(unittest.TestCase):
                 simh=self.data[kind]["simh"],
                 simp=self.data[kind]["simp"],
                 kind=kind,
-                goup="time.month",  # default
+                group="time.month",  # default
             )
             assert isinstance(result, xr.core.dataarray.DataArray)
             for lat in range(len(self.data[kind]["obsh"].lat)):


### PR DESCRIPTION
Now the `adjust_3d` method will not use any grouping if group is set to `None`, since this behaviour would disable the chance to be called by external individual functions that does not require a grouping.