### PR TITLE
Fixed PyPI repository URL

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,6 +74,6 @@ jobs:
     name: Upload the current release to PyPI
     uses: ./.github/workflows/_pypi_publish.yml
     with:
-      REPOSITORY_URL: https://pypi.org/simple
+      REPOSITORY_URL: https://upload.pypi.org/legacy/
     secrets:
       API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
# Summary
* Changed the upload URL for the PyPI prod package upload