### PR TITLE
Resolve "Adjustments using `adjust` require the input data of the control period to have the same size for the time dimension"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,36 @@
 # Changelog
 
-## [v2.0.0](https://github.com/btschwertfeger/python-cmethods/tree/v2.0.0) (2023-01-23)
+## [Unreleased](https://github.com/btschwertfeger/python-cmethods/tree/HEAD)
+
+[Full Changelog](https://github.com/btschwertfeger/python-cmethods/compare/v2.0.2...HEAD)
+
+**Merged pull requests:**
+
+- Fix typos and update pre-commit hooks [\#64](https://github.com/btschwertfeger/python-cmethods/pull/64) ([btschwertfeger](https://github.com/btschwertfeger))
+
+## [v2.0.2](https://github.com/btschwertfeger/python-cmethods/tree/v2.0.2) (2024-02-02)
+
+[Full Changelog](https://github.com/btschwertfeger/python-cmethods/compare/v2.0.1...v2.0.2)
+
+**Merged pull requests:**
+
+- Update documentation -- QM and QDM formulas [\#62](https://github.com/btschwertfeger/python-cmethods/pull/62) ([btschwertfeger](https://github.com/btschwertfeger))
+- Bump GitHub action versions [\#59](https://github.com/btschwertfeger/python-cmethods/pull/59) ([btschwertfeger](https://github.com/btschwertfeger))
+
+## [v2.0.1](https://github.com/btschwertfeger/python-cmethods/tree/v2.0.1) (2024-02-01)
+
+[Full Changelog](https://github.com/btschwertfeger/python-cmethods/compare/v2.0.0...v2.0.1)
+
+**Closed issues:**
+
+- The latest documentation still describes the legacy max_scaling_factor [\#60](https://github.com/btschwertfeger/python-cmethods/issues/60)
+
+**Merged pull requests:**
+
+- adjust CI workflows [\#58](https://github.com/btschwertfeger/python-cmethods/pull/58) ([btschwertfeger](https://github.com/btschwertfeger))
+- Resolve "The latest documentation still describes the legacy max scaling factor" [\#61](https://github.com/btschwertfeger/python-cmethods/pull/61) ([btschwertfeger](https://github.com/btschwertfeger))
+
+## [v2.0.0](https://github.com/btschwertfeger/python-cmethods/tree/v2.0.0) (2024-01-23)
 
 [Full Changelog](https://github.com/btschwertfeger/python-cmethods/compare/v1.0.3...v2.0.0)
 
@@ -12,6 +42,10 @@
 
 - Optimization for `adjust_3d` [\#47](https://github.com/btschwertfeger/python-cmethods/issues/47)
 - Find a solution to process large data sets more efficient [\#6](https://github.com/btschwertfeger/python-cmethods/issues/6)
+
+**Merged pull requests:**
+
+- Fix the CodeQL workflow execution; prepare v2.0.0 release [\#50](https://github.com/btschwertfeger/python-cmethods/pull/50) ([btschwertfeger](https://github.com/btschwertfeger))
 
 ## [v1.0.3](https://github.com/btschwertfeger/python-cmethods/tree/v1.0.3) (2023-08-09)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-orange.svg)](https://www.gnu.org/licenses/gpl-3.0)
 [![Downloads](https://pepy.tech/badge/python-cmethods)](https://pepy.tech/project/python-cmethods)
 
-![CodeQL](https://github.com/btschwertfeger/python-cmethods/actions/workflows/codeql.yaml/badge.svg)
 [![CI/CD](https://github.com/btschwertfeger/python-cmethods/actions/workflows/cicd.yaml/badge.svg?branch=master)](https://github.com/btschwertfeger/python-cmethods/actions/workflows/cicd.yaml)
 [![codecov](https://codecov.io/github/btschwertfeger/python-cmethods/branch/master/graph/badge.svg?token=OSO4PAABPD)](https://codecov.io/github/btschwertfeger/python-cmethods)
 

--- a/cmethods/core.py
+++ b/cmethods/core.py
@@ -171,6 +171,8 @@ def adjust(
         simh_group = group["simh"]
         simp_group = group["simp"]
 
+    del kwargs["group"]
+
     result: Optional[XRData] = None
     for (_, obs_gds), (_, simh_gds), (_, simp_gds) in zip(
         obs.groupby(obs_group),

--- a/cmethods/core.py
+++ b/cmethods/core.py
@@ -50,26 +50,45 @@ def apply_ufunc(
     if method not in __METHODS_FUNC__:
         raise UnknownMethodError(method, __METHODS_FUNC__.keys())
 
+    if kwargs.get("input_core_dims"):
+        if not isinstance(kwargs["input_core_dims"], dict):
+            raise TypeError("input_core_dims must be an object of type 'dict'")
+        if not len(kwargs["input_core_dims"]) == 3 or any(
+            not isinstance(value, str) for value in kwargs["input_core_dims"].values()
+        ):
+            raise ValueError(
+                "input_core_dims must have three key-value pairs like: "
+                '{"obs": "time", "simh": "time", "simp": "time"}',
+            )
+
+        input_core_dims = kwargs["input_core_dims"]
+    else:
+        input_core_dims = {"obs": "time", "simh": "time", "simp": "time"}
+
     result: XRData = xr.apply_ufunc(
         __METHODS_FUNC__[method],
         obs,
         simh,
         # Need to spoof a fake time axis since 'time' coord on full dataset is different
         # than 'time' coord on training dataset.
-        simp.rename({"time": "t2"}),
+        simp.rename({input_core_dims["simp"]: "__t_simp__"}),
         dask="parallelized",
         vectorize=True,
         # This will vectorize over the time dimension, so will submit each grid cell
         # independently
-        input_core_dims=[["time"], ["time"], ["t2"]],
+        input_core_dims=[
+            [input_core_dims["obs"]],
+            [input_core_dims["simh"]],
+            ["__t_simp__"],
+        ],
         # Need to denote that the final output dataset will be labeled with the
         # spoofed time coordinate
-        output_core_dims=[["t2"]],
+        output_core_dims=[["__t_simp__"]],
         kwargs=dict(kwargs),
     )
 
     # Rename to proper coordinate name.
-    result = result.rename({"t2": "time"})
+    result = result.rename({"__t_simp__": input_core_dims["simp"]})
 
     # ufunc will put the core dimension to the end (time), so want to preserve original
     # order where time is commonly first.
@@ -89,6 +108,14 @@ def adjust(
     requirements and execution examples.
 
     See https://python-cmethods.readthedocs.io/en/latest/src/methods.html
+
+
+    The time dimension of ``obs``, ``simh`` and ``simp`` must be named ``time``.
+
+    If the sizes of time dimensions of the input data sets differ, you have to
+    pass the hidden ``input_core_dims`` parameter, see
+    https://python-cmethods.readthedocs.io/en/latest/src/getting_started.html#advanced-usage
+    for more information.
 
     :param method: Technique to apply
     :type method: str
@@ -127,14 +154,28 @@ def adjust(
         )
 
     # Grouped correction | scaling-based technique
-    group: str = kwargs["group"]
-    del kwargs["group"]
+    group: str | dict[str, str] = kwargs["group"]
+    if isinstance(group, str):
+        # only for same sized time dimensions
+        obs_group = group
+        simh_group = group
+        simp_group = group
+    elif isinstance(group, dict):
+        if any(key not in {"obs", "simh", "simp"} for key in group):
+            raise ValueError(
+                "group must either be a string like 'time' or a dict like "
+                '{"obs": "time.month", "simh": "t_simh.month", "simp": "time.month"}',
+            )
+        # for different sized time dimensions
+        obs_group = group["obs"]
+        simh_group = group["simh"]
+        simp_group = group["simp"]
 
     result: Optional[XRData] = None
     for (_, obs_gds), (_, simh_gds), (_, simp_gds) in zip(
-        obs.groupby(group),
-        simh.groupby(group),
-        simp.groupby(group),
+        obs.groupby(obs_group),
+        simh.groupby(simh_group),
+        simp.groupby(simp_group),
     ):
         monthly_result = apply_ufunc(
             method,

--- a/cmethods/distribution.py
+++ b/cmethods/distribution.py
@@ -62,6 +62,11 @@ def quantile_mapping(
 
     cdf_obs = get_cdf(obs, xbins)
     cdf_simh = get_cdf(simh, xbins)
+    cdf_simh = np.interp(
+        cdf_simh,
+        (cdf_simh.min(), cdf_simh.max()),
+        (cdf_obs.min(), cdf_obs.max()),
+    )
 
     if kind in ADDITIVE:
         epsilon = np.interp(simp, xbins, cdf_simh)  # Eq. 1
@@ -124,6 +129,11 @@ def detrended_quantile_mapping(
 
     cdf_obs = get_cdf(obs, xbins)
     cdf_simh = get_cdf(simh, xbins)
+    cdf_simh = np.interp(
+        cdf_simh,
+        (cdf_simh.min(), cdf_simh.max()),
+        (cdf_obs.min(), cdf_obs.max()),
+    )
 
     # detrended => shift mean of $X_{sim,p}$ to range of $X_{sim,h}$ to adjust extremes
     res = np.zeros(len(simp.values))

--- a/doc/links.rst
+++ b/doc/links.rst
@@ -27,9 +27,6 @@
 .. |Downloads badge| image:: https://static.pepy.tech/personalized-badge/python-cmethods?period=total&units=abbreviation&left_color=grey&right_color=orange&left_text=downloads
    :target: https://pepy.tech/project/python-cmethods
 
-.. |CodeQL badge| image:: https://github.com/btschwertfeger/python-cmethods/actions/workflows/codeql.yaml/badge.svg?branch=master
-   :target: https://github.com/btschwertfeger/python-cmethods/actions/workflows/codeql.yaml
-
 .. |CI/CD badge| image:: https://github.com/btschwertfeger/python-cmethods/actions/workflows/cicd.yaml/badge.svg?branch=master
    :target: https://github.com/btschwertfeger/python-cmethods/actions/workflows/cicd.yaml
 

--- a/doc/src/getting_started.rst
+++ b/doc/src/getting_started.rst
@@ -56,3 +56,60 @@ method specific documentation.
         n_quaniles=1000,
         kind="+",
     )
+
+
+Advanced Usage
+--------------
+
+In some cases the time dimension of input data sets have different sizes. In
+such case, the hidden parameter ``input_core_dims`` must be passed to the
+``adjust`` call.
+
+It defines the dimension names of the input data sets, i.e. if the time
+dimensions of ``obs`` and ``simp`` have the length, but the time dimension of
+``simh`` is somewhat smaller, you have to define this as follows:
+
+
+.. code-block:: python
+    :linenos:
+    :caption: Bias Adjustments for data sets with different time dimension lengths pt. 1
+
+    from cmethods import adjust
+    import xarray as xr
+
+    obs = xr.open_dataset("examples/input_data/observations.nc")["tas"]
+    simp = xr.open_dataset("examples/input_data/control.nc")["tas"]
+    simh = simp.copy(deep=True)[3650:]
+
+    bc = adjust(
+        method="quantile_mapping",
+        obs=obs,
+        simh=simh.rename({"time": "t_simh"}),
+        simp=simh,
+        kind="+",
+        input_core_dims={"obs": "time", "simh": "t_simh", "simp": "time"}
+    )
+
+In case you are applying a scaling based technique using grouping, you have to
+adjust the group names accordingly to the time dimension names.
+
+.. code-block:: python
+    :linenos:
+    :caption: Bias Adjustments for data sets with different time dimension lengths pt. 2
+
+    from cmethods import adjust
+    import xarray as xr
+
+    obs = xr.open_dataset("examples/input_data/observations.nc")["tas"]
+    simp = xr.open_dataset("examples/input_data/control.nc")["tas"]
+    simh = simp.copy(deep=True)[3650:]
+
+    bc = adjust(
+        method="linear_scaling",
+        obs=obs,
+        simh=simh.rename({"time": "t_simh"}),
+        simp=simh,
+        kind="+",
+        group={"obs": "time.month", "simh": "t_simh.month", "simp": "time.month"},
+        input_core_dims={"obs": "time", "simh": "t_simh", "simp": "time"}
+    )

--- a/doc/src/introduction.rst
+++ b/doc/src/introduction.rst
@@ -4,7 +4,7 @@ Introduction
 =============
 
 |GitHub badge| |License badge| |PyVersions badge| |Downloads badge|
-|CodeQL badge| |CI/CD badge| |codecov badge|
+|CI/CD badge| |codecov badge|
 |Release date badge| |Release version badge| |DOI badge| |Docs stable|
 
 About

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -39,10 +39,10 @@ from cmethods.utils import (
 def test_quantile_mapping_single_nan() -> None:
     obs, simh, simp = list(np.arange(10)), list(np.arange(10)), list(np.arange(10))
     obs[0] = np.nan
-    expected = np.array([0.0, 1.9, 2.9, 3.9, 4.9, 5.9, 6.9, 7.9, 8.9, 9.0])
+    expected = np.array([0.0, 1.8, 2.7, 3.6, 4.5, 5.4, 6.3, 7.2, 8.1, 9.0])
 
     res = quantile_mapping(obs=obs, simh=simh, simp=simp, n_quantiles=5)
-    assert np.allclose(res, expected)
+    assert np.allclose(res, expected), res
 
 
 @pytest.mark.filterwarnings("ignore:All-NaN slice encountered")


### PR DESCRIPTION
The discussion on https://github.com/btschwertfeger/python-cmethods/discussions/65 has shown an error that occurs, when using a workaround to adjust a data set based on control period data with differently shaped time-dimensions. 

1. So the first issue that this PR is addressing is to enable to use differently sized control period data for the adjustment. From now on, the time dimension of the modeled data of the control period must not have the same length as the time dimension of the reference data of the control period.

2. The main issue that the mentioned discussion is about, is a strange result when applying the methods to un-evenly shaped data. The problem is described in more detail in https://github.com/btschwertfeger/python-cmethods/discussions/65#discussioncomment-8720345. So to fix this, we now interpolate the cumulative distribution functions of the modeled data of the control period to the value range of the passed reference data. 

Since the second issue was not present in this package, as it was only visible when just copying or hacking around, a single feature PR is sufficient, no further issues must be created. 