### PR TITLE
Fix missing function documentation

### DIFF
--- a/.github/workflows/_build_doc.yaml
+++ b/.github/workflows/_build_doc.yaml
@@ -34,8 +34,8 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install -r doc/requirements.txt
           python -m pip install .
+          python -m pip install -r doc/requirements.txt
 
       - name: Build the documentation
         run: cd doc && make html

--- a/.github/workflows/_build_doc.yaml
+++ b/.github/workflows/_build_doc.yaml
@@ -35,6 +35,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install -r doc/requirements.txt
+          python -m pip install .
 
       - name: Build the documentation
         run: cd doc && make html

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,15 +10,16 @@
 
 """This module is the configuration for the Sphinx documentation building process"""
 
-import os
 import sys
+from pathlib import Path
 
 project = "python-cmethods"
 copyright = "2023, Benjamin Thomas Schwertfeger"  # pylint: disable=redefined-builtin
 author = "Benjamin Thomas Schwertfeger"
 
 # to import the package
-sys.path.insert(0, os.path.abspath("..").resolve())
+parent_directory: Path = Path("..").resolve()
+sys.path.insert(0, str(parent_directory))
 
 # import links
 rst_epilog = ""

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -51,6 +51,5 @@ html_context = {
     "display_github": True,
     "github_user": "btschwertfeger",
     "github_repo": "python-cmethods",
-    "github_version": "master/docs/",
+    "github_version": "master/doc/",
 }
-# html_theme_options = {

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ copyright = "2023, Benjamin Thomas Schwertfeger"  # pylint: disable=redefined-bu
 author = "Benjamin Thomas Schwertfeger"
 
 # to import the package
-sys.path.insert(0, os.path.abspath(".."))
+sys.path.insert(0, os.path.abspath("..").resolve())
 
 # import links
 rst_epilog = ""

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -18,7 +18,7 @@ copyright = "2023, Benjamin Thomas Schwertfeger"  # pylint: disable=redefined-bu
 author = "Benjamin Thomas Schwertfeger"
 
 # to import the package
-parent_directory: Path = Path("..").resolve()
+parent_directory = Path("..").resolve()
 sys.path.insert(0, str(parent_directory))
 
 # import links

--- a/doc/license.rst
+++ b/doc/license.rst
@@ -8,4 +8,4 @@
 License
 =======
 
-.. include:: ../../LICENSE
+.. include:: ../LICENSE

--- a/doc/methods.rst
+++ b/doc/methods.rst
@@ -6,9 +6,20 @@
 Bias Correction Methods
 =======================
 
-Please note that the formulas are meant to be applied to a single time series.
-The python-cmethods package can apply these formulas to single and
-multidimensional data.
+General
+-------
+
+- Please note that the formulas are meant to be applied to a single time series.
+  The python-cmethods package can apply these formulas to single and
+  multidimensional data.
+- Selecting the appropriate number of quantiles for distribution-based
+  techniques is a challenging task. The number of quantiles determines the
+  number of bins of the probability density function and the cumulative
+  distribution function, which represent the distribution of the time series.
+  The number of quantiles should be large enough to capture the nuances of the
+  distribution functions but not excessively high, as this can result in a
+  straight-line distribution, which lead to artificial bias while interpolating.
+
 
 .. _linear-scaling:
 

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,7 +1,7 @@
+cloup
 netCDF4>=1.6.1
 numpy
 setuptools_scm
 sphinx
 sphinx-rtd-theme
-tqdm
 xarray>=2022.11.0


### PR DESCRIPTION
The documentation was somehow broken - documentation of functions as well as the license were missing. This was fixed by adjusting the build settings.

Additionally I dropped some lines about what the quantiles parameter is used for. 