### PR TITLE
Do not rely on trusted publishing for PyPI upload

### DIFF
--- a/.github/workflows/_pypi_publish.yaml
+++ b/.github/workflows/_pypi_publish.yaml
@@ -10,6 +10,9 @@ name: PyPI Publish
 
 on:
   workflow_call:
+    secrets:
+      API_TOKEN:
+        required: true
 
 permissions: read-all
 
@@ -35,4 +38,5 @@ jobs:
       - name: Publish package distributions to PyPI (optional - testpypi)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.API_TOKEN }}
           repository-url: https://upload.pypi.org/legacy/

--- a/.github/workflows/_pypi_test_publish.yaml
+++ b/.github/workflows/_pypi_test_publish.yaml
@@ -10,6 +10,9 @@ name: PyPI Publish
 
 on:
   workflow_call:
+    secrets:
+      API_TOKEN:
+        required: true
 
 permissions: read-all
 
@@ -32,4 +35,5 @@ jobs:
       - name: Publish package distributions to PyPI (optional - testpypi)
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
+          password: ${{ secrets.API_TOKEN }}
           repository-url: https://test.pypi.org/legacy/

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -17,7 +17,7 @@ on:
     types: [created]
 
 concurrency:
-  group: CICD-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -101,6 +101,8 @@ jobs:
       - CodeQL
     name: Upload current version to Test PyPI
     uses: ./.github/workflows/_pypi_test_publish.yaml
+    secrets:
+      API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
 
   ##    Upload the python-kraken-sdk to Production PyPI
   ##
@@ -116,3 +118,5 @@ jobs:
       - CodeQL
     name: Upload the current release to PyPI
     uses: ./.github/workflows/_pypi_publish.yaml
+    secrets:
+      API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Trusted publishing only works if no template workflows are used. So this repo needs to return to API token-based authentication.