### PR TITLE
Rename CITATION file suffix

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,9 +1,9 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite it as below."
 authors:
-- family-names: "Schwertfeger"
-  given-names: "Benjamin Thomas"
-  orcid: "https://orcid.org/0000-0001-7664-8434"
+  - family-names: "Schwertfeger"
+    given-names: "Benjamin Thomas"
+    orcid: "https://orcid.org/0000-0001-7664-8434"
 title: "python-cmethods"
 doi: 10.5281/zenodo.7652755
 url: "https://github.com/btschwertfeger/python-cmethods"


### PR DESCRIPTION
Updating the file suffix for the citation file to be properly presented in Zenodo.